### PR TITLE
Recognize flask-restful boolean type in reqparse

### DIFF
--- a/flask_restful_swagger_2/__init__.py
+++ b/flask_restful_swagger_2/__init__.py
@@ -268,6 +268,8 @@ class _RequestParserExtractorImpl(_BaseExtractorImpl):
         """
         if hasattr(type_, 'swagger_type'):
             return type_.swagger_type
+        elif callable(type_) and type_.__name__ == 'boolean':  # flask-restful boolean
+            return 'boolean'
         elif issubclass(type_, basestring):
             return 'string'
         elif type_ == float:


### PR DESCRIPTION
This allows flask_restful.inputs boolean type to be recognized without erroring out.  Otherwise you end up with a TypeError from the issubclass check.